### PR TITLE
switched to git version rather than subversion

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign no-dependencies
 
-GIT_DEF = -D'GIT_REV="$(shell git describe --tags)"'
+GIT_DEF = -D'GIT_REV="$(shell git describe --tags --dirty)"'
 AM_CFLAGS = -g -O3 -std=gnu99 -ffast-math -DPACKAGE_DATA_DIR=\"$(pkgdatadir)\" $(GIT_DEF)
 
 ACLOCAL_AMFLAGS = -I m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 AUTOMAKE_OPTIONS = foreign no-dependencies
 
-SVN_DEF = -D'SVN_REV="$(shell svnversion -n .)"'
-AM_CFLAGS = -g -O3 -std=gnu99 -ffast-math -DPACKAGE_DATA_DIR=\"$(pkgdatadir)\" $(SVN_DEF)
+GIT_DEF = -D'GIT_REV="$(shell git describe --tags)"'
+AM_CFLAGS = -g -O3 -std=gnu99 -ffast-math -DPACKAGE_DATA_DIR=\"$(pkgdatadir)\" $(GIT_DEF)
 
 ACLOCAL_AMFLAGS = -I m4
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -359,7 +359,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-GIT_DEF = -D'GIT_REV="$(shell git describe --tags)"'
+GIT_DEF = -D'GIT_REV="$(shell git describe --tags --dirty)"'
 AM_CFLAGS = -g -O3 -std=gnu99 -ffast-math -DPACKAGE_DATA_DIR=\"$(pkgdatadir)\" $(GIT_DEF)
 ACLOCAL_AMFLAGS = -I m4
 man1_MANS = flam3-animate.man flam3-genome.man flam3-render.man flam3-convert.man

--- a/Makefile.in
+++ b/Makefile.in
@@ -359,8 +359,8 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = foreign no-dependencies
-SVN_DEF = -D'SVN_REV="$(shell svnversion -n .)"'
-AM_CFLAGS = -g -O3 -std=gnu99 -ffast-math -DPACKAGE_DATA_DIR=\"$(pkgdatadir)\" $(SVN_DEF)
+GIT_DEF = -D'GIT_REV="$(shell git describe --tags)"'
+AM_CFLAGS = -g -O3 -std=gnu99 -ffast-math -DPACKAGE_DATA_DIR=\"$(pkgdatadir)\" $(GIT_DEF)
 ACLOCAL_AMFLAGS = -I m4
 man1_MANS = flam3-animate.man flam3-genome.man flam3-render.man flam3-convert.man
 lib_LTLIBRARIES = libflam3.la

--- a/flam3.c
+++ b/flam3.c
@@ -61,8 +61,8 @@
 
 char *flam3_version() {
 
-  if (strcmp(SVN_REV, "exported"))
-    return flam3_os "-" VERSION "." SVN_REV;
+  if (strcmp(GIT_REV, ""))
+    return flam3_os "-" VERSION "." GIT_REV;
   return flam3_os "-" VERSION;
 }
 


### PR DESCRIPTION
git describe --tags will return a string indicating the number of commits since the last tag.  I tagged the version after we fixed the O3 issue as 3.0.1.

Example:
v3.0.1-5-gd52cd96

5 commits past tag 3.0.1, with a partial checksum for the commit.
