### PR TITLE
Clarify in README.txt that GPLv3 'or later' is compatible

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,5 +1,9 @@
 FLAM3 - cosmic recursive fractal flames
-see the file COPYING for the license covering this software.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
 
 This is free software to render fractal flames as described on
 http://flam3.com.  Flam3-animate makes animations, and flam3-render


### PR DESCRIPTION
Currently, the README just refers to COPYING for licensing information, but
COPYING just contains the GPLv3, and doesn't specify whether redistribution
under later versions of the GPL is also allowed.

The source files all clearly specify that redistribution under later versions
of the GPL is indeed allowed, so it might be nice to also make that obvious in
the README?