### PR TITLE
build: Fix undefined libm references.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,19 +11,20 @@ lib_LTLIBRARIES = libflam3.la
 include_HEADERS = flam3.h isaac.h isaacs.h rect.c
 
 libflam3_la_SOURCES = flam3.c filters.c parser.c variations.c interpolation.c palettes.c jpeg.c png.c isaac.c
-libflam3_la_LDFLAGS = -no-undefined -ljpeg -lpng -lz -lpthread
+libflam3_la_LDFLAGS = -no-undefined
+libflam3_la_LIBADD = -ljpeg -lpng -lz -lpthread $(LIBM)
 
 flam3_genome_SOURCES = flam3-genome.c docstring.c
-flam3_genome_LDADD = libflam3.la -lm
+flam3_genome_LDADD = libflam3.la
 
 flam3_animate_SOURCES = flam3-animate.c docstring.c
-flam3_animate_LDADD = libflam3.la -lm
+flam3_animate_LDADD = libflam3.la
 
 flam3_render_SOURCES = flam3-render.c docstring.c
-flam3_render_LDADD = libflam3.la -lm
+flam3_render_LDADD = libflam3.la
 
 flam3_convert_SOURCES = flam3-convert.c docstring.c
-flam3_convert_LDADD = libflam3.la -lm
+flam3_convert_LDADD = libflam3.la
 
 pkgdata_DATA = flam3-palettes.xml
 

--- a/configure.ac
+++ b/configure.ac
@@ -28,6 +28,8 @@ AC_CHECK_LIB([z],[deflateInit_],,[AC_MSG_ERROR([zlib is required.])])
 AC_CHECK_LIB([png],[png_write_image],,[AC_MSG_ERROR([The png library is required.])])
 AC_CHECK_LIB([xml2],[xmlParseFile],,[AC_MSG_ERROR([The xml2 library is required.])])
 
+AC_CHECK_LIBM
+AC_SUBST([LIBM])
 
 if test "${enable_atomic_ops}" = "" ; then
   enable_atomic_ops=yes


### PR DESCRIPTION
When building flam3 with slibtool (https://dev.midipix.org/cross/slibtool) it fails with many references to libm indicating a missing `-lm` for `libflam3_la_LIBADD`. This happens because it uses `-no-undefined` and GNU libtool does not fail because it silently ignores `-no-undefined`.

Additionally I moved the dependencies to `LIBADD` where they should be and removed the `-lm` from the `LDADD` variables where its now redundant.

Please see this downstream issue: https://bugs.gentoo.org/779001